### PR TITLE
Update to Minecraft 1.19

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -1,5 +1,5 @@
 dependencies {
-    compileOnly("io.papermc.paper", "paper-api", "1.17.1-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper", "paper-api", "1.19-R0.1-SNAPSHOT")
     compileOnlyApi("org.checkerframework", "checker-qual", "3.15.0")
 }
 
@@ -7,6 +7,6 @@ java {
     withJavadocJar()
     withSourcesJar()
 
-    targetCompatibility = JavaVersion.toVersion(16)
-    sourceCompatibility = JavaVersion.toVersion(16)
+    targetCompatibility = JavaVersion.toVersion(17)
+    sourceCompatibility = JavaVersion.toVersion(17)
 }

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -7,13 +7,13 @@ plugins {
 
 dependencies {
     implementation(project(":pl3xmap-api"))
-    val cloudVersion = "1.6.2"
+    val cloudVersion = "1.7.0-SNAPSHOT"
     implementation("cloud.commandframework", "cloud-paper", cloudVersion)
     implementation("cloud.commandframework", "cloud-minecraft-extras", cloudVersion)
-    implementation("net.kyori", "adventure-text-minimessage", "4.10.0")
+    implementation("net.kyori", "adventure-text-minimessage", "4.11.0")
     implementation("io.undertow", "undertow-core", "2.2.3.Final")
     implementation("org.bstats", "bstats-bukkit", "2.2.1")
-    paperDevBundle("1.18.2-R0.1-SNAPSHOT")
+    paperDevBundle("1.19-R0.1-SNAPSHOT")
 }
 
 tasks {
@@ -36,7 +36,7 @@ tasks {
         dependsOn(reobfJar)
     }
     runServer {
-        minecraftVersion("1.18.1")
+        minecraftVersion("1.19")
     }
 }
 
@@ -52,7 +52,7 @@ java {
 bukkit {
     main = "net.pl3x.map.plugin.Pl3xMapPlugin"
     name = rootProject.name
-    apiVersion = "1.18"
+    apiVersion = "1.19"
     website = "https://github.com/NeumimTo/Pl3xMap"
     authors = listOf("BillyGalbreath", "jmp", "NeumimTo")
 }

--- a/plugin/src/main/java/net/pl3x/map/plugin/network/Network.java
+++ b/plugin/src/main/java/net/pl3x/map/plugin/network/Network.java
@@ -9,7 +9,7 @@ import net.pl3x.map.plugin.data.MapWorld;
 import net.pl3x.map.plugin.listener.PlayerListener;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
-import org.bukkit.craftbukkit.v1_18_R2.map.CraftMapRenderer;
+import org.bukkit.craftbukkit.v1_19_R1.map.CraftMapRenderer;
 import org.bukkit.entity.Player;
 import org.bukkit.map.MapRenderer;
 import org.bukkit.map.MapView;

--- a/plugin/src/main/java/net/pl3x/map/plugin/util/ReflectionUtil.java
+++ b/plugin/src/main/java/net/pl3x/map/plugin/util/ReflectionUtil.java
@@ -2,7 +2,7 @@ package net.pl3x.map.plugin.util;
 
 import net.minecraft.server.level.ServerLevel;
 import org.bukkit.World;
-import org.bukkit.craftbukkit.v1_18_R2.CraftWorld;
+import org.bukkit.craftbukkit.v1_19_R1.CraftWorld;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 


### PR DESCRIPTION
I saw on Discord (support channel) that you didn't have access to your PC, so I thought: let's update this thing myself! 🙂 The plugin should now work on Paper 1.19. Or at least, it does on my PC.